### PR TITLE
Bump immutable library, fix changes to updateIn API

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dist/morearty.min.js"
   ],
   "dependencies": {
-    "immutable": "^2.0.6"
+    "immutable": "^2.0.14"
   },
   "devDependencies": {
     "chai": "^1.9.1",

--- a/src/Binding.js
+++ b/src/Binding.js
@@ -117,9 +117,9 @@ define(['Dyn', 'Util', 'util/Holder'], function (Dyn, Util, Holder) {
         break;
       default:
         var key = effectivePath[len - 1];
-        newBackingValue = backingValue.updateIn(pathTo, function (coll) {
+        newBackingValue = backingValue.has(pathTo[0]) && backingValue.updateIn(pathTo, function (coll) {
           return deleteValue(coll, key);
-        });
+        }) || backingValue;
     }
 
     setBackingValue(binding, newBackingValue);
@@ -344,7 +344,8 @@ define(['Dyn', 'Util', 'util/Holder'], function (Dyn, Util, Holder) {
     /** Clear nested collection.
      * @param {String|Array} [subpath] subpath as a dot-separated string or an array of strings and numbers */
     clear: function (subpath) {
-      this.update(subpath, function (coll) {
+      subpath = asArrayPath(subpath);
+      if (getBackingValue(this).getIn(subpath)) this.update(subpath, function (coll) {
         return clear(coll);
       });
     },

--- a/test/Binding.js
+++ b/test/Binding.js
@@ -143,11 +143,10 @@ describe('Binding', function () {
   });
 
   describe('#update(update, subpath)', function () {
-    it('should do nothing on non-existent subpath', function () {
+    it('should create subpaths if they don\'t exist', function () {
       var b = Binding.init(Map({ key1: Map({ key2: 0 }) }));
-      var originalValue = b.val();
       b.update('non.existent', Util.constantly('foo'));
-      assert.strictEqual(b.val(), originalValue);
+      assert.strictEqual(b.val('non.existent'), 'foo');
     });
 
     it('should do nothing if value isn\'t changed', function () {
@@ -205,11 +204,10 @@ describe('Binding', function () {
   });
 
   describe('#set(newValue, subpath)', function () {
-    it('should do nothing on non-existent subpath', function () {
+    it('should create paths if they don\'t exist', function () {
       var b = Binding.init(Map({ key1: Map({ key2: 0 }) }));
-      var originalValue = b.val();
       b.set('non.existent', 'foo');
-      assert.strictEqual(b.val(), originalValue);
+      assert.strictEqual(b.val('non.existent'), 'foo');
     });
 
     it('should do nothing if value isn\'t changed', function () {
@@ -263,7 +261,7 @@ describe('Binding', function () {
   });
 
   describe('#delete(subpath)', function () {
-    it('should do nothing on non-existent subpath', function () {
+    it('should do nothing on non-existent subpaths', function () {
       var b = Binding.init(Map({ key1: Map({ key2: 0 }) }));
       var originalValue = b.val();
       b.delete('non.existent');
@@ -314,11 +312,11 @@ describe('Binding', function () {
   });
 
   describe('#merge(subpath, preserve, newValue)', function () {
-    it('should do nothing on non-existent subpath', function () {
+    it('should create paths if they don\'t exist', function () {
       var b = Binding.init(Map.empty());
       var originalValue = b.val();
       b.merge('non.existent', false, 'foo');
-      assert.strictEqual(b.val(), originalValue);
+      assert.strictEqual(b.val('non.existent'), 'foo');
     });
 
     it('should deep merge new value into old value by default', function () {
@@ -383,7 +381,7 @@ describe('Binding', function () {
   });
 
   describe('#clear(subpath)', function () {
-    it('should do nothing on non-existent subpath', function () {
+    it('should do nothing on non-existent subpaths', function () {
       var b = Binding.init(Map({ key1: Map({ key2: 0 }) }));
       var originalValue = b.val();
       b.clear('non.existent');


### PR DESCRIPTION
Five of the tests are failing with the latest Immutable, now that `updateIn` creates maps at places where there aren't any. For the set / update this seems to make sense, for the delete/clear it didn't seem to.

This fixes that.
