### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/a7ae129b709c3e6acfad
-    on_success: change
+    on_success: always
     on_failure: always
     on_start: false


### PR DESCRIPTION
This will always alert on Gitter when builds are successful. The previous attribute, would only trigger events when it wen't from `failed` to `pass`.
