### PR TITLE
Fix undefined reference to window (nodejs)

### DIFF
--- a/src/Morearty.js
+++ b/src/Morearty.js
@@ -74,7 +74,7 @@ var merge = function (mergeStrategy, defaultState, stateBinding) {
 };
 
 var getRenderRoutine = function (self) {
-  var requestAnimationFrame = window && window.requestAnimationFrame;
+  var requestAnimationFrame = (typeof window !== 'undefined') && window.requestAnimationFrame;
   var fallback = function (f) { setTimeout(f, 1000 / 60); };
 
   if (self._configuration.requestAnimationFrameEnabled) {


### PR DESCRIPTION
The reference to window throws a reference error when executed in node.
This is not really cool if one wants to render something server side.
This simple commit should make it work.
