### PR TITLE
Added a stack trace to error handling.

### DIFF
--- a/src/Morearty.js
+++ b/src/Morearty.js
@@ -289,7 +289,7 @@ Context.prototype = Object.freeze( /** @lends Context.prototype */ {
         }
 
         console.error('Morearty: render error. ' + (stop ? 'Exiting.' : 'Continuing.'));
-        console.error('Error details: ' + e.message);
+        console.error('Error details: %s', e.message, e.stack);
       }
     };
 


### PR DESCRIPTION
At the moment error handling is a bit opaque...

e.g. 
```
 Morearty: render error. Continuing.
Morearty.js:292 Error details: undefined is not a function
```


This pull requests adds the stack trace to the error logging.

e.g.
```
 Morearty: render error. Continuing.
Morearty.js:292 Error details: undefined is not a function TypeError: undefined is not a function
    at eval (webpack:///./views/planting/New.jsx?:84:109)
    at eval (webpack:///../~/immutable/dist/immutable.js?:1139:46)
    at eval (webpack:///../~/immutable/dist/immutable.js?:3173:43)
    at List.__iterate (webpack:///../~/immutable/dist/immutable.js?:2688:13)
    at OrderedMap.__iterate (webpack:///../~/immutable/dist/immutable.js?:3172:25)
    at KeyedIterable.mappedSequence.__iterateUncached (webpack:///../~/immutable/dist/immutable.js?:1138:23)
    at seqIterate (webpack:///../~/immutable/dist/immutable.js?:601:16)
    at KeyedIterable.Seq.__iterate (webpack:///../~/immutable/dist/immutable.js?:261:14)
    at KeyedIterable.mixin.forEach (webpack:///../~/immutable/dist/immutable.js?:4256:19)
    at eval (webpack:///../~/immutable/dist/immutable.js?:3125:16)Morearty.js:292 catchingRenderErrorsMorearty.js:301 render
```