### PR TITLE
fix delete aliases set after freeze

### DIFF
--- a/src/Binding.js
+++ b/src/Binding.js
@@ -317,7 +317,7 @@ Binding.asStringPath = function (pathAsAnArray) {
  * @type {String} */
 Binding.META_NODE = META_NODE;
 
-Binding.prototype = Object.freeze( /** @lends Binding.prototype */ {
+var bindingPrototype = /** @lends Binding.prototype */ {
 
   /** Get binding path.
    * @returns {Array} binding path */
@@ -544,9 +544,11 @@ Binding.prototype = Object.freeze( /** @lends Binding.prototype */ {
     return new TransactionContext(this);
   }
 
-});
+};
 
-Binding.prototype['delete'] = Binding.prototype.remove;
+bindingPrototype['delete'] = bindingPrototype.remove;
+
+Binding.prototype = Object.freeze(bindingPrototype);
 
 /** Transaction context constructor.
  * @param {Binding} binding binding
@@ -645,7 +647,7 @@ TransactionContext.prototype = (function () {
     }
   };
 
-  return Object.freeze( /** @lends TransactionContext.prototype */ {
+  var transactionContextPrototype = /** @lends TransactionContext.prototype */ {
 
     /** Update binding value.
      * @param {Binding} [binding] binding to apply update to
@@ -749,9 +751,12 @@ TransactionContext.prototype = (function () {
       }
     }
 
-  });
+  };
+
+  transactionContextPrototype['delete'] = transactionContextPrototype.remove;
+
+  return Object.freeze(transactionContextPrototype);
 })();
 
-TransactionContext.prototype['delete'] = TransactionContext.prototype.remove;
 
 module.exports = Binding;

--- a/test/Binding.js
+++ b/test/Binding.js
@@ -386,6 +386,12 @@ describe('Binding', function () {
     });
   });
 
+  describe('#delete', function () {
+    it('should strictly equal #remove', function () {
+      assert.strictEqual(Binding.prototype.remove, Binding.prototype['delete']);
+    });
+  });
+
   describe('#remove(subpath)', function () {
     it('should return this binding', function () {
       var b = Binding.init(IMap({ key: 'value' }));
@@ -845,6 +851,14 @@ describe('TransactionContext', function () {
       var b = Binding.init(IMap({ key: 'value' }));
       var tx = b.atomically();
       assert.strictEqual(tx.set('key', 'foo'), tx);
+    });
+  });
+
+  describe('#delete', function () {
+    it('should strictly equal #remove', function () {
+      var b = Binding.init(IMap({ key: 'value' }));
+      var tx = b.atomically();
+      assert.strictEqual(tx.remove, tx['delete']);
     });
   });
 

--- a/test/util/Callback.js
+++ b/test/util/Callback.js
@@ -46,6 +46,12 @@ describe('Callback', function () {
     });
   });
 
+  describe('#delete', function () {
+    it('should strictly equal #remove', function () {
+      assert.strictEqual(Callback.remove, Callback['delete']);
+    });
+  });
+
   describe('#remove()', function () {
     it('should return function which will delete value on an event', function () {
       var b = Binding.init(IMap({ key: 'value' }));


### PR DESCRIPTION
i also added a test for `Callback.delete` even though it wasn't broken