### PR TITLE
Expose nextContext in shouldComponentUpdateOverride()

### DIFF
--- a/src/Morearty.js
+++ b/src/Morearty.js
@@ -554,7 +554,7 @@ module.exports = {
       initDefaultMetaState(this);
     },
 
-    shouldComponentUpdate: function (nextProps, nextState) {
+    shouldComponentUpdate: function (nextProps, nextState, nextContext) {
       var self = this;
       var ctx = self.getMoreartyContext();
       var shouldComponentUpdate = function () {
@@ -567,7 +567,7 @@ module.exports = {
 
       var shouldComponentUpdateOverride = self.shouldComponentUpdateOverride;
       return shouldComponentUpdateOverride ?
-        shouldComponentUpdateOverride(shouldComponentUpdate, nextProps, nextState) :
+        shouldComponentUpdateOverride(shouldComponentUpdate, nextProps, nextState, nextContext) :
         shouldComponentUpdate();
     },
 


### PR DESCRIPTION
Current React v0.13 calls shouldComponentUpdateOverride() with three arguments: props, state, and context. Needs this argument to deal with custom user-defined contexts.