### PR TITLE
Ob queue simplified

### DIFF
--- a/src/Morearty.js
+++ b/src/Morearty.js
@@ -444,6 +444,10 @@ Context.prototype = Object.freeze( /** @lends Context.prototype */ {
     this._componentQueue[component.componentQueueId] = component;
   },
 
+  removeComponentFromRenderQueue: function (component) {
+    delete this._componentQueue[component.componentQueueId];
+  },
+
   getUniqueComponentQueueId: function () {
     return ++this._lastComponentQueueId;
   },
@@ -574,7 +578,7 @@ module.exports = {
       var self = this;
       this._observedListenerIds.push(
         binding.addListener(function (changes) {
-          self.context.morearty.addComponentToRenderQueue(self);
+          self.getMoreartyContext().addComponentToRenderQueue(self);
         })
       );
     },
@@ -658,7 +662,7 @@ module.exports = {
     },
 
     componentDidUpdate: function () {
-      delete this.getMoreartyContext()._componentQueue[this.componentQueueId];
+      this.getMoreartyContext().removeComponentFromRenderQueue(this);
       savePreviousState(this);
     },
 

--- a/src/Morearty.js
+++ b/src/Morearty.js
@@ -219,7 +219,7 @@ var Context = function (binding, metaBinding, options) {
   this._fullUpdateInProgress = false;
 
   /** @private */
-  this._componentQueue = {};
+  this._componentQueue = [];
 
   /** @private */
   this._lastComponentQueueId = 0;
@@ -390,22 +390,20 @@ Context.prototype = Object.freeze( /** @lends Context.prototype */ {
         if (self._fullUpdateQueued) {
           self._fullUpdateInProgress = true;
 
-          for (k in self._componentQueue) {
-            c = self._componentQueue[k];
+          self._componentQueue.forEach(function (c, i) {
             if (c.shouldComponentUpdate(c.props, c.state)) c.forceUpdate();
-          }
-          self._componentQueue = {};
+          });
+          self._componentQueue = [];
 
           rootComp.forceUpdate(function () {
             self._fullUpdateQueued = false;
             self._fullUpdateInProgress = false;
           });
         } else {
-          for (k in self._componentQueue) {
-            c = self._componentQueue[k];
+          self._componentQueue.forEach(function (c, i) {
             if (c.shouldComponentUpdate(c.props, c.state)) c.forceUpdate();
-          }
-          self._componentQueue = {};
+          });
+          self._componentQueue = [];
 
           rootComp.forceUpdate();
         }
@@ -617,6 +615,9 @@ module.exports = {
     shouldComponentUpdate: function (nextProps, nextState, nextContext) {
       var self = this;
       var ctx = self.getMoreartyContext();
+
+      delete ctx._componentQueue[this.componentQueueId];
+
       var shouldComponentUpdate = function () {
         return ctx._fullUpdateInProgress ||
             stateChanged(self, getBinding(nextProps), getBinding(self.props)) ||

--- a/src/Morearty.js
+++ b/src/Morearty.js
@@ -569,7 +569,7 @@ module.exports = {
 
     /** Get component previous state value.
      * @param {String} [name] binding name (can only be used with multi-binding state)
-     * @return {Binding} previous component state value */
+     * @return {Object} previous props.binding resolved to Immutables {Binding, Binding,...} --> {Immutable, Immutable,...} */
     getPreviousState: function (name) {
       return this._previousState;
     },

--- a/src/Morearty.js
+++ b/src/Morearty.js
@@ -225,9 +225,6 @@ var Context = function (binding, metaBinding, options) {
 
   /** @private */
   this._lastComponentQueueId = 0;
-
-  /** @private */
-  this._componentQueueUpdateInProgress = false;
 };
 
 Context.prototype = Object.freeze( /** @lends Context.prototype */ {
@@ -391,7 +388,6 @@ Context.prototype = Object.freeze( /** @lends Context.prototype */ {
       self._renderQueued = false;
 
       catchingRenderErrors(function () {
-        var k,c;
         if (self._fullUpdateQueued) {
           self._fullUpdateInProgress = true;
 
@@ -669,7 +665,7 @@ module.exports = {
     componentWillUnmount: function () {
       var binding = this.getDefaultBinding();
       if (binding) {
-        var remover = binding.removeListener.bind(binding); // <-- should use Binding.prototype instead I think @todo
+        var remover = binding.removeListener.bind(binding);
         this._observedListenerIds.forEach(remover);
         this._observedListenerIds = [];
 

--- a/src/Morearty.js
+++ b/src/Morearty.js
@@ -391,7 +391,7 @@ Context.prototype = Object.freeze( /** @lends Context.prototype */ {
           self._fullUpdateInProgress = true;
 
           self._componentQueue.forEach(function (c, i) {
-            if (c.shouldComponentUpdate(c.props, c.state)) c.forceUpdate();
+            c.forceUpdate();
           });
           self._componentQueue = [];
 
@@ -401,7 +401,7 @@ Context.prototype = Object.freeze( /** @lends Context.prototype */ {
           });
         } else {
           self._componentQueue.forEach(function (c, i) {
-            if (c.shouldComponentUpdate(c.props, c.state)) c.forceUpdate();
+            c.forceUpdate();
           });
           self._componentQueue = [];
 

--- a/src/Morearty.js
+++ b/src/Morearty.js
@@ -577,7 +577,6 @@ module.exports = {
 
     setupObservedBindingListener: function (binding) {
       var self = this;
-      this.componentQueueId = this.context.morearty.getUniqueComponentQueueId();
       this._observedListenerIds.push(
         binding.addListener(function (changes) {
           self.context.morearty.addComponentToRenderQueue(self);
@@ -606,6 +605,8 @@ module.exports = {
     },
 
     componentWillMount: function () {
+      this.componentQueueId = this.context.morearty.getUniqueComponentQueueId();
+
       initDefaultState(this);
       initDefaultMetaState(this);
 
@@ -666,6 +667,7 @@ module.exports = {
       if (binding) {
         var remover = binding.removeListener.bind(binding); // <-- should use Binding.prototype instead I think @todo
         this._observedListenerIds.forEach(remover);
+        this._observedListenerIds = [];
 
         if (typeof this.shouldRemoveListeners === 'function' && this.shouldRemoveListeners()) {
           var listenersBinding = binding.meta('listeners');

--- a/test/Morearty.js
+++ b/test/Morearty.js
@@ -1230,6 +1230,7 @@ describe('Morearty', function () {
         var initialState = IMap({ key1: 'value1', key2: 'value2' });
         var ctx = createCtx(initialState);
 
+        var key1Binding = ctx.getBinding().sub('key1');
         var key2Binding = ctx.getBinding().sub('key2');
         var renderCalledTimes = 0;
         var render2CalledTimes = 0;
@@ -1259,10 +1260,12 @@ describe('Morearty', function () {
         React.render(bootstrapComp(), global.document.getElementById('root'));
 
         assert.strictEqual(renderCalledTimes, 1);
+        assert.strictEqual(render2CalledTimes, 1);
 
+        key1Binding.set('bar');
         key2Binding.set('foo');
         waitRender(function () {
-          assert.strictEqual(renderCalledTimes, 1);
+          assert.strictEqual(renderCalledTimes, 2);
           assert.strictEqual(render2CalledTimes, 2);
           done();
         });


### PR DESCRIPTION
- Includes major change to `stateChanged` and how previous state is tracked per component which ensures that SCU returns false after render.

- No longer need to check if OB changed in SCU.

- Simplified `stateChanged`.

- I'm not sure if i should have overwritten the old `Mixin#getPreviousState`