### PR TITLE
avoid savePreviousState error for non-binding

### DIFF
--- a/src/Morearty.js
+++ b/src/Morearty.js
@@ -161,7 +161,7 @@ initDefaultMetaState = function (self) {
 
 savePreviousState = function (self) {
   var binding = self.props.binding;
-  if (binding) {
+  if (binding instanceof Object) {
     var ctx = self.getMoreartyContext();
     self._previousMetaState = ctx && ctx.getCurrentMeta();
     if (binding instanceof Binding) {
@@ -170,7 +170,7 @@ savePreviousState = function (self) {
       self._previousState = {};
       Object.keys(self.props.binding)
         .forEach(function (key) {
-          self._previousState[key] = self.props.binding[key] && self.props.binding[key].get();
+          self._previousState[key] = (self.props.binding[key] instanceof Binding) && self.props.binding[key].get();
         });
     }
   } else {

--- a/test/Morearty.js
+++ b/test/Morearty.js
@@ -2048,4 +2048,46 @@ describe('Morearty', function () {
     });
 
   });
+
+  describe('savePreviousState', function () {
+    it('should not error when binding prop is not a proper Binding', function (done) {
+      var initialState = IMap({ key: 'foo' });
+      var ctx = createCtx(initialState);
+      var didRender = false;
+      var value;
+
+      var subComp = createClass({
+        render: function () {
+          var realBinding = this.getBinding('real');
+          if (realBinding) value = realBinding.get();
+          didRender = true;
+          return null;
+        }
+      });
+
+      var rootComp = createClass({
+        render: function () {
+          return React.createElement(
+                  "div",
+                  null,
+                  React.createFactory(subComp)({ binding: 'fake' }),
+                  React.createFactory(subComp)({ binding: {
+                    real: this.getDefaultBinding().sub('key'),
+                    fake: 'fake'
+                  }})
+                );
+        }
+      });
+
+      var bootstrapComp = React.createFactory(ctx.bootstrap(rootComp));
+
+      React.render(bootstrapComp(), global.document.getElementById('root'));
+
+      waitRender(function () {
+        assert.isTrue(didRender);
+        assert.strictEqual(value, 'foo');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
I'm not sure if this is the best solution. The problem is that you get a really un-useful stack trace if you pass an improper binding, such as `binding="foo"` or `binding={ default: realBinding.sub('foo'), bad: 'fake' }`. This fix just skips any binding that is poorly formed.